### PR TITLE
enable images using query strings

### DIFF
--- a/function.resize.php
+++ b/function.resize.php
@@ -45,7 +45,7 @@ function resize($imagePath,$opts=null){
 
 	$purl = parse_url($imagePath);
 	$finfo = pathinfo($imagePath);
-	$ext = $finfo['extension'];
+	list($ext) = explode("?",$finfo['extension']);
 
 	# check for remote image..
 	if(isset($purl['scheme']) && ($purl['scheme'] == 'http' || $purl['scheme'] == 'https')):


### PR DESCRIPTION
Images with query strings failed before this patch because tjhe name of the file was not reckognized. Code is pretty self-explanatory.
